### PR TITLE
veneur-proxy: Add option for GRPC streaming to veneur-global

### DIFF
--- a/config_proxy.go
+++ b/config_proxy.go
@@ -16,6 +16,7 @@ type ProxyConfig struct {
 	ForwardTimeout               string               `yaml:"forward_timeout"`
 	GrpcAddress                  string               `yaml:"grpc_address"`
 	GrpcForwardAddress           string               `yaml:"grpc_forward_address"`
+	GrpcStream                   bool                 `yaml:"grpc_stream"`
 	HTTPAddress                  string               `yaml:"http_address"`
 	IdleConnectionTimeout        string               `yaml:"idle_connection_timeout"`
 	IgnoreTags                   []matcher.TagMatcher `yaml:"ignore_tags"`

--- a/proxy.go
+++ b/proxy.go
@@ -281,6 +281,7 @@ func NewProxyFromConfig(
 			proxysrv.WithIgnoredTags(proxy.ignoredTags),
 			proxysrv.WithLog(logrus.NewEntry(logger)),
 			proxysrv.WithTraceClient(proxy.TraceClient),
+			proxysrv.WithEnableStreaming(conf.GrpcStream),
 		)
 		if err != nil {
 			logger.WithError(err).Fatal("Failed to initialize the gRPC server")

--- a/proxysrv/options.go
+++ b/proxysrv/options.go
@@ -45,3 +45,9 @@ func WithTraceClient(c *trace.Client) Option {
 		opts.traceClient = c
 	}
 }
+
+func WithEnableStreaming(streaming bool) Option {
+	return func(opts *options) {
+		opts.streaming = true
+	}
+}

--- a/proxysrv/options.go
+++ b/proxysrv/options.go
@@ -48,6 +48,6 @@ func WithTraceClient(c *trace.Client) Option {
 
 func WithEnableStreaming(streaming bool) Option {
 	return func(opts *options) {
-		opts.streaming = true
+		opts.streaming = streaming
 	}
 }

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -51,8 +51,6 @@ type Server struct {
 	conns        *clientConnMap
 	updateMtx    sync.Mutex
 
-	streaming bool
-
 	// A simple counter to track the number of goroutines spawned to handle
 	// proxying metrics
 	activeProxyHandlers *int64
@@ -320,10 +318,10 @@ func (s *Server) forward(ctx context.Context, dest string, ms []*metricpb.Metric
 
 	c := forwardrpc.NewForwardClient(conn)
 
-	if s.streaming {
+	if s.opts.streaming {
 		forwardStream, err := c.SendMetricsV2(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to send %d metrics over gRPC: %v",
+			return fmt.Errorf("failed to stream %d metrics over gRPC: %v",
 				len(ms), err)
 		}
 

--- a/proxysrv/server.go
+++ b/proxysrv/server.go
@@ -325,7 +325,7 @@ func (s *Server) forward(ctx context.Context, dest string, ms []*metricpb.Metric
 				len(ms), err)
 		}
 
-		defer forwardStream.CloseSend()
+		defer forwardStream.CloseAndRecv()
 
 		for i, metric := range ms {
 			err := forwardStream.Send(metric)


### PR DESCRIPTION
## Context

I've switched the veneur pipeline in our production clusters to using gRPC in order to address a [bug](https://github.com/stripe/veneur/issues/815). Unfortunately, in large clusters the batches produced by veneur are significantly larger that the default MaxRecvSize (4MiB) in the gRPC library.

Here's the error message:
>veneur-pfj5s veneur time=“2022-11-17T18:46:21Z” level=error msg=“Failed to forward to an upstream Veneur” destination=“veneur-proxy:8128” error=“rpc error: code = ResourceExhausted desc = grpc: received message larger than max (4798168 vs. 4194304)” grpcstate=READY metrics=19408 protocol=grpc

This error was easily resolved by enabling gRPC streaming in the veneur DaemonSet ([configuration](https://github.com/stripe/veneur/blob/dd54c5efdfae7f8070155c90e9a480fcc85ad76b/config.go#L38)).

After enabling this streaming feature, I discovered that problem had now moved upstream to veneur-proxy. Veneur-proxy was now logging the same error. Unfortunately, gRPC streaming is not configurable within veneur-proxy. So, I've had to add the feature.

We've been running this patch in all of our clusters for the past week.